### PR TITLE
Allow password auth for local Snowflake testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Set the following variables to connect to Snowflake:
 - `SNOWFLAKE_DATABASE`
 - `SNOWFLAKE_SCHEMA`
 - `SNOWFLAKE_PRIVATE_KEY` – base64 encoded private key
+- `SNOWFLAKE_PASSWORD` – optional password for local testing
 - `SNOWFLAKE_QUERY_TAG` – optional query tag
 
-These can alternatively be defined in a local `config.py` when running the app on your machine.
+These variables can also be defined in a local `config.py` for development. If `SNOWFLAKE_PRIVATE_KEY` is not provided, the application will attempt password authentication using `SNOWFLAKE_PASSWORD`.
 
 ## Running the Server Locally
 


### PR DESCRIPTION
## Summary
- add password fallback in `create_snowpark_session`
- document optional `SNOWFLAKE_PASSWORD` environment variable

## Testing
- `python -m py_compile app.py archive_app_for_issues.py`
- `pip install -r requirements.txt`
- `python app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae4d3fb08325b0f2b70a73d7459a