### PR TITLE
Fix 6 UI/UX issues from production review

### DIFF
--- a/app.py
+++ b/app.py
@@ -1166,7 +1166,7 @@ def auth_request_access():
     if g.user:
         return redirect(url_for('leaderboard'))
     if not is_registration_open():
-        return redirect(url_for('auth_login'))
+        return redirect(url_for('auth_login', msg='registration_closed'))
     return render_template('request_access.html')
 
 
@@ -1295,6 +1295,7 @@ def leaderboard():
                          last_updated=last_updated,
                          cut_line=metadata.get('cut_line') if metadata else None,
                          player_scores=player_scores,
+                         picks_locked=tournament.get('picks_locked', True),
                          is_fallback=False,
                          user=g.user)
 
@@ -1430,12 +1431,12 @@ def make_picks():
     # Sort by OWGR rank (lower is better)
     golfers.sort(key=lambda x: x['owgr_rank'] or 999)
 
-    golfer_names = [g['name'] for g in golfers]
+    golfer_data = [{'name': g['name'], 'rank': i + 1} for i, g in enumerate(golfers)]
 
     # Split into tiers
-    first = golfer_names[:5]
-    second = golfer_names[5:16]
-    third = golfer_names[16:]
+    first = golfer_data[:5]
+    second = golfer_data[5:16]
+    third = golfer_data[16:]
 
     return render_template('pick_form.html',
                          tournament_name=tournament['name'],

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,11 +62,11 @@
         <div class="max-w-6xl mx-auto px-4 py-4">
             {# --- Authenticated nav: tabs + auth controls --- #}
             {% if show_nav is defined and show_nav %}
-            <div class="flex items-center justify-between">
+            <div class="flex flex-wrap items-center justify-between gap-y-2">
                 <a href="/" class="font-display text-xl text-golf-gold-400 flex-shrink-0">
                     80 Yard Bombs Cup
                 </a>
-                <div class="flex items-center space-x-2">
+                <div class="order-last w-full sm:w-auto sm:order-none flex items-center space-x-2">
                     <nav class="flex items-center bg-turf-800 rounded-lg p-1">
                         <a href="/" class="px-3 py-1.5 text-xs font-medium {{ 'text-white bg-golf-green-600' if active_tab == 'leaderboard' else 'text-gray-300 hover:text-white hover:bg-gray-700' }} rounded-md transition-colors">
                             Board
@@ -116,7 +116,7 @@
 
     <footer class="border-t border-gray-800/50 py-4 mt-auto">
         <div class="max-w-6xl mx-auto px-4 text-center text-xs text-gray-600">
-            80 Yard Bombs Cup &middot; {{ season_year or '2025' }}
+            80 Yard Bombs Cup &middot; {{ season_year }}
         </div>
     </footer>
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -7,17 +7,7 @@
 
 {% block header_class %}sticky top-0 z-50 backdrop-blur-sm{% endblock %}
 
-{% block nav_extra %}
-<!-- Expand/Collapse Toggle -->
-<button id="expandToggle" class="expand-toggle" aria-label="Expand all teams" title="Expand all teams">
-    <svg class="toggle-icon expand-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-    <svg class="toggle-icon collapse-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-    </svg>
-</button>
-{% endblock %}
+{% block nav_extra %}{% endblock %}
 
 {% block nav_subtitle %}
 <div class="mt-1">
@@ -67,6 +57,20 @@
 {% block main_class %}max-w-6xl mx-auto px-4 py-4{% endblock %}
 
 {% block content %}
+<!-- Expand/Collapse Toggle -->
+{% if results %}
+<div class="flex justify-end mb-3">
+    <button id="expandToggle" class="expand-toggle" aria-label="Expand all teams" title="Expand all teams">
+        <svg class="toggle-icon expand-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+        <svg class="toggle-icon collapse-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+        </svg>
+    </button>
+</div>
+{% endif %}
+
 <!-- Leaderboard Cards -->
 <div class="space-y-3">
     {% for row in results %}
@@ -165,8 +169,16 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
         </svg>
     </div>
-    <h3 class="text-lg font-medium text-gray-300 mb-2">No entries yet</h3>
+    {% if not picks_locked %}
+    <h3 class="text-lg font-medium text-gray-300 mb-2">No picks submitted yet</h3>
+    <p class="text-gray-500 mb-6">The tournament is open for picks — be the first to enter!</p>
+    <a href="/make_picks" class="inline-block px-6 py-3 bg-gradient-to-r from-golf-green-600 to-golf-green-700 hover:from-golf-green-500 hover:to-golf-green-600 text-white font-semibold rounded-lg shadow-lg transition-all duration-200">
+        Make Your Picks
+    </a>
+    {% else %}
+    <h3 class="text-lg font-medium text-gray-300 mb-2">No entries for this tournament</h3>
     <p class="text-gray-500">Check back soon for tournament results!</p>
+    {% endif %}
 </div>
 {% endif %}
 {% endblock %}
@@ -239,7 +251,8 @@
     }
 
     document.addEventListener('DOMContentLoaded', function() {
-        document.getElementById('expandToggle').addEventListener('click', toggleAllCards);
+        const expandToggle = document.getElementById('expandToggle');
+        if (expandToggle) expandToggle.addEventListener('click', toggleAllCards);
         function bindChips() {
             document.querySelectorAll('.player-chip').forEach(chip => {
                 chip.addEventListener('click', function(e) {
@@ -256,10 +269,11 @@
         // Auto-expand all cards on desktop
         if (window.innerWidth >= 768) {
             document.querySelectorAll('.team-card').forEach(card => toggleContent(card));
-            const toggle = document.getElementById('expandToggle');
-            toggle.classList.add('collapse-mode');
-            toggle.querySelector('.expand-icon').classList.add('hidden');
-            toggle.querySelector('.collapse-icon').classList.remove('hidden');
+            if (expandToggle) {
+                expandToggle.classList.add('collapse-mode');
+                expandToggle.querySelector('.expand-icon').classList.add('hidden');
+                expandToggle.querySelector('.collapse-icon').classList.remove('hidden');
+            }
         }
     });
 </script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,6 +23,12 @@
         </div>
         {% endif %}
 
+        {% if request.args.get('msg') == 'registration_closed' %}
+        <div class="mb-6 p-4 bg-gray-700/50 border border-gray-600 rounded-lg">
+            <p class="text-gray-300 text-sm">Registration is currently closed. Sign in if you already have an account.</p>
+        </div>
+        {% endif %}
+
         <form action="/auth/request-link" method="POST" class="space-y-6">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 

--- a/templates/pick_form.html
+++ b/templates/pick_form.html
@@ -56,6 +56,13 @@
             background-color: transparent !important;
             color: #f9fafb !important;
         }
+        /* Ensure dropdowns start closed */
+        .choices[data-type*=select-multiple] .choices__list--dropdown {
+            display: none;
+        }
+        .choices.is-open .choices__list--dropdown {
+            display: block;
+        }
     </style>
 {% endblock %}
 
@@ -156,7 +163,7 @@
                             required>
                             <option value="">Select a golfer...</option>
                             {% for golfer in first %}
-                            <option value="{{ golfer }}">{{ golfer }}</option>
+                            <option value="{{ golfer.name }}">{{ golfer.name }} (#{{ golfer.rank }})</option>
                             {% endfor %}
                         </select>
                         <div class="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
@@ -177,7 +184,7 @@
                     </label>
                     <select name="golfer_2_and_3" class="choices-multiple w-full" multiple required>
                         {% for golfer in second %}
-                        <option value="{{ golfer }}">{{ golfer }}</option>
+                        <option value="{{ golfer.name }}">{{ golfer.name }} (#{{ golfer.rank }})</option>
                         {% endfor %}
                     </select>
                     <p class="text-xs text-gray-500">Choose two golfers ranked 6-16</p>
@@ -192,7 +199,7 @@
                     </label>
                     <select name="golfer_4_and_5" class="choices-multiple w-full" multiple required>
                         {% for golfer in third %}
-                        <option value="{{ golfer }}">{{ golfer }}</option>
+                        <option value="{{ golfer.name }}">{{ golfer.name }} (#{{ golfer.rank }})</option>
                         {% endfor %}
                     </select>
                     <p class="text-xs text-gray-500">Choose two golfers ranked 17 or lower</p>

--- a/templates/player_standings.html
+++ b/templates/player_standings.html
@@ -48,8 +48,8 @@
 
 {% block content %}
         <!-- Stats Summary Cards -->
-        <div class="grid grid-cols-3 gap-4 mb-8">
-            <div class="bg-gray-800 rounded-lg p-4 border border-gray-700">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-8">
+            <div class="bg-gray-800 rounded-lg p-3 sm:p-4 border border-gray-700">
                 <div class="text-2xl font-bold text-golf-green-500">
                     {% set all_teams = [] %}
                     {% for row in results %}
@@ -61,15 +61,15 @@
                             {% endfor %}
                         {% endif %}
                     {% endfor %}
-                    {{ all_teams|length }}
+                    {% if all_teams|length == 0 %}&mdash;{% else %}{{ all_teams|length }}{% endif %}
                 </div>
-                <div class="text-xs text-gray-400 uppercase tracking-wide">Total Teams Entered</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide">{% if all_teams|length == 0 %}No Picks Yet{% else %}Total Teams Entered{% endif %}</div>
             </div>
-            <div class="bg-gray-800 rounded-lg p-4 border border-gray-700">
+            <div class="bg-gray-800 rounded-lg p-3 sm:p-4 border border-gray-700">
                 <div class="text-2xl font-bold text-golf-gold-400">{{ results|length }}</div>
                 <div class="text-xs text-gray-400 uppercase tracking-wide">Unique Players Selected</div>
             </div>
-            <div class="bg-gray-800 rounded-lg p-4 border border-gray-700">
+            <div class="bg-gray-800 rounded-lg p-3 sm:p-4 border border-gray-700">
                 <div class="text-2xl font-bold text-red-400">
                     {% if cut_line %}
                         {% if cut_line > 0 %}+{{ cut_line|int }}{% elif cut_line < 0 %}{{ cut_line|int }}{% else %}E{% endif %}


### PR DESCRIPTION
## Summary
- **Mobile header**: Wrap nav tabs to second row on small screens so toggle/logout don't clip off-screen
- **Leaderboard empty state**: Show "Make Your Picks" CTA button when picks are open instead of generic message
- **Pick form dropdowns**: Force Choices.js multi-select dropdowns closed on page load; show OWGR rank numbers next to golfer names
- **Registration closed banner**: Show informational message on login page when redirected from closed registration
- **Player standings mobile**: Stack stat cards vertically on mobile to prevent text clipping; show dash instead of "0" when no teams exist
- **Footer year**: Remove stale 2025 fallback, rely on context processor

## Test plan
- [ ] Mobile (390px): verify header wraps brand and nav to two rows, all controls visible
- [ ] Leaderboard with no entries + picks unlocked: verify green "Make Your Picks" button appears
- [ ] Leaderboard with no entries + picks locked: verify "No entries for this tournament" message
- [ ] Pick form: verify dropdowns start collapsed, golfer names show rank (e.g. "Scottie Scheffler (#1)")
- [ ] Visit `/auth/request-access` with registration closed: verify redirect to login with "Registration is currently closed" banner
- [ ] Player standings mobile: verify stat cards stack vertically, no text clipping
- [ ] Footer: verify shows "2026" (current year)

🤖 Generated with [Claude Code](https://claude.com/claude-code)