### PR TITLE
Disable in-dropdown search on Make Picks selectors

### DIFF
--- a/templates/pick_form.html
+++ b/templates/pick_form.html
@@ -506,13 +506,14 @@ document.addEventListener('turbo:load', () => {
 
     // ── Choices.js init ────────────────────────────────────────────────────────
     const sharedConfig = {
-        searchEnabled: true,
+        // Search is disabled on purpose: focusing the search input pops the iOS
+        // keyboard, which covers most of the dropdown and leaves only a couple of
+        // golfers visible to scroll. Users tap to select from the full list instead.
+        searchEnabled: false,
         placeholder: true,
-        noResultsText: 'No golfers found',
         itemSelectText: '',
         shouldSort: false,
         allowHTML: false,
-        searchPlaceholderValue: 'Search golfers...',
         classNames: {
             containerOuter: 'choices',
             containerInner: 'choices__inner',


### PR DESCRIPTION
## Problem

On mobile, tapping a golfer selector on the Make Picks page focused a Choices.js search input, which popped the iOS keyboard. The keyboard covered the bottom half of the screen, leaving only ~2 golfers visible in the dropdown to scroll through — making the selectors frustrating to use.

## Change

Disable `searchEnabled` on all three selectors (Top 5, Mid-Field, Long Shots). Tapping now opens the full golfer list to tap-select from, and the keyboard never appears. Also drops the now-unused search-only config keys (`noResultsText`, `searchPlaceholderValue`).

Since both the single-select and multi-select configs spread `sharedConfig`, this is a single-flag change that covers every selector. Remove-item buttons, the live pick counters, and the "All 2 picks made" message are unaffected.

## Follow-up to #34

This is the second half of the Make Picks mobile fixes. #34 (self-host + pin Choices.js, add a load-failure fallback banner) was merged; this commit was authored after that merge and applies on top of it.

## Trade-off

The Long Shot tier (17+) can be a large field, so its dropdown becomes a longer scroll with no way to jump to a name. This was the chosen behavior (no keyboard anywhere); search can be re-enabled on just that one selector later if the scroll proves tedious.

## Verification

- `pick_form.html` passes a Jinja2 compile check and the scripts block passes a JavaScript syntax check.
- Confirmed no remaining references to the removed search-only config keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTUbf3v96s1W2dRDDZ8a1J)_