### PR TITLE
Wire up Data Golf as temporary Open Championship data source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt

--- a/app.py
+++ b/app.py
@@ -1499,6 +1499,11 @@ def fetch_tournament_field(tournament_external_id, year=None):
 
 def refresh_golfers_from_api(tournament_id, tournament_external_id, year=None):
     """Refresh golfer data from Slash Golf API."""
+    # The Open Championship 2026: Slash Golf API disabled by provider mid-tournament.
+    # Temporary Data Golf source — remove this whole branch next season.
+    if tournament_external_id == '100':
+        return refresh_golfers_from_datagolf(tournament_id, tournament_external_id, year)
+
     if year is None:
         year = datetime.now().year
 
@@ -1579,6 +1584,186 @@ def refresh_golfers_from_api(tournament_id, tournament_external_id, year=None):
     """, [tournament_id, cut_line])
 
     db.commit()
+    return True
+
+
+# =============================================================================
+# Data Golf integration — TEMPORARY 2026 stopgap for The Open Championship.
+# The Slash Golf API was disabled by its provider mid-tournament. Data Golf is
+# wired in only for The Open (gated by external_id == '100' in
+# refresh_golfers_from_api). Remove this whole section next season.
+# =============================================================================
+
+DATAGOLF_BASE_URL = "https://feeds.datagolf.com"
+
+# Data Golf uses different name spellings/nicknames for a handful of players.
+# These 4 are non-picked golfers that don't normalize-match an existing row;
+# map the raw Data Golf name to the exact golfers.name already in the DB.
+DG_NAME_ALIASES = {
+    'Sloman, Tom': 'Thomas Sloman',
+    'Smyth, Trav': 'Travis Smyth',
+    'Grinberg, Lev': 'Liv Grinberg',
+    'Skogen, Baard': 'Bard Bjoernevikl Skogen',
+}
+
+
+def _datagolf_flip_name(name):
+    """Convert a Data Golf 'Last, First' name to 'First Last'."""
+    if ',' in name:
+        last, first = name.split(',', 1)
+        return f"{first.strip()} {last.strip()}"
+    return name.strip()
+
+
+def _format_golf_score(value):
+    """Format an integer golf score for display: 0->'E', -2->'-2', 3->'+3', None->'--'."""
+    if value is None:
+        return '--'
+    if value == 0:
+        return 'E'
+    return f"+{value}" if value > 0 else str(value)
+
+
+def fetch_datagolf_in_play():
+    """Fetch live in-play data from Data Golf's PGA feed. Returns a dict or None."""
+    api_key = os.getenv('DG_API_KEY')
+    if not api_key:
+        logger.error("DG_API_KEY not set — cannot fetch Data Golf in-play data")
+        return None
+    try:
+        resp = requests.get(
+            f"{DATAGOLF_BASE_URL}/preds/in-play",
+            params={'tour': 'pga', 'file_format': 'json', 'key': api_key},
+            timeout=15
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"Error fetching Data Golf in-play data: {e}")
+        return None
+
+
+def refresh_golfers_from_datagolf(tournament_id, tournament_external_id, year=None):
+    """Refresh The Open Championship golfer scores from Data Golf.
+
+    Existing golfer rows are UPDATEd in place (matched by normalized name) —
+    never inserted — so pick-to-golfer matching and row identity are preserved.
+    Data Golf returns names as 'Last, First' and provides no numeric cut line;
+    both are handled here. Returns True on success, False on any failure (which
+    leaves last-good data untouched, same as the Slash Golf path).
+    """
+    data = fetch_datagolf_in_play()
+    if not isinstance(data, dict):
+        return False
+
+    info = data.get('info') or {}
+    event_name = (info.get('event_name') or '')
+    if 'open championship' not in event_name.lower():
+        logger.warning(
+            "Data Golf in-play event is '%s', not The Open — skipping refresh",
+            event_name
+        )
+        return False
+
+    players = data.get('data') or []
+    if not players:
+        logger.warning("Data Golf in-play returned no players — skipping refresh")
+        return False
+
+    db = get_db()
+
+    # Map normalized name -> existing DB golfer name so we UPDATE in place.
+    existing = db.execute(
+        "SELECT name FROM golfers WHERE tournament_id = ?", [tournament_id]
+    ).fetchall()
+    norm_to_db = {_normalize_golfer_name(r[0]): r[0] for r in existing}
+
+    made_cut_scores = []
+    has_cut = False
+    matched = 0
+    unmatched = []
+
+    for player in players:
+        raw_name = player.get('player_name', '')
+        if not raw_name:
+            continue
+
+        db_name = norm_to_db.get(_normalize_golfer_name(_datagolf_flip_name(raw_name)))
+        if db_name is None:
+            db_name = DG_NAME_ALIASES.get(raw_name)
+        if db_name is None:
+            unmatched.append(raw_name)
+            continue
+
+        pos = player.get('current_pos')
+        total = player.get('current_score')
+        today = player.get('today')
+        rnd = player.get('round')
+        thru = player.get('thru')
+
+        total = int(total) if isinstance(total, (int, float)) else None
+        today = int(today) if isinstance(today, (int, float)) else None
+        rnd = int(rnd) if isinstance(rnd, (int, float)) else None
+
+        pos_str = str(pos).upper() if pos is not None else ''
+        is_cut = pos_str in ('CUT', 'MC')
+        is_ranked = bool(pos_str) and (pos_str[0].isdigit() or pos_str.startswith('T'))
+
+        if is_cut:
+            status = 'cut'
+            has_cut = True
+        elif total is None:
+            status = 'not started'
+        else:
+            status = 'active'
+
+        # Cut line = worst total among players who made the cut (are still ranked).
+        if is_ranked and total is not None:
+            made_cut_scores.append(total)
+
+        db.execute("""
+            UPDATE golfers SET
+                position = ?,
+                total_score = ?,
+                score_display = ?,
+                current_round_score = ?,
+                round_number = ?,
+                thru = ?,
+                status = ?,
+                last_updated = datetime('now')
+            WHERE tournament_id = ? AND name = ?
+        """, [
+            str(pos) if pos is not None else '',
+            total,
+            _format_golf_score(total),
+            _format_golf_score(today),
+            rnd,
+            str(thru) if thru is not None else '',
+            status,
+            tournament_id,
+            db_name,
+        ])
+        matched += 1
+
+    # Data Golf exposes no cut-line score; derive it only once the cut is in.
+    cut_line = max(made_cut_scores) if (has_cut and made_cut_scores) else None
+
+    db.execute("""
+        INSERT INTO tournament_metadata (tournament_id, cut_line, last_api_update, api_status)
+        VALUES (?, ?, datetime('now'), 'success')
+        ON CONFLICT(tournament_id) DO UPDATE SET
+            cut_line = excluded.cut_line,
+            last_api_update = datetime('now'),
+            api_status = 'success'
+    """, [tournament_id, cut_line])
+
+    db.commit()
+
+    if unmatched:
+        logger.warning("Data Golf refresh: %d unmatched players skipped: %s",
+                       len(unmatched), ', '.join(unmatched))
+    logger.info("Data Golf refresh: updated %d golfers for The Open (cut_line=%s)",
+                matched, cut_line)
     return True
 
 

--- a/docs/superpowers/specs/2026-07-16-datagolf-open-hotfix-design.md
+++ b/docs/superpowers/specs/2026-07-16-datagolf-open-hotfix-design.md
@@ -1,0 +1,160 @@
+# Data Golf Hot-Fix for The Open Championship 2026
+
+**Date:** 2026-07-16
+**Status:** Approved design → implementation
+**Author:** Cullin + Claude
+
+## Problem
+
+The Slash Golf API (`live-golf-data.p.rapidapi.com`), the app's sole golfer-score
+data source, was disabled by the provider mid-tournament. Every endpoint returns:
+
+```
+HTTP 405 {"message":"The API provider has disabled request access to the API..."}
+```
+
+As a result, `refresh_golfers_from_api()` fails on every call, `last_api_update`
+is frozen at `2026-07-15 11:37 UTC`, and The Open Championship leaderboard shows
+no live scores. The Open's 156 golfer rows currently have `total_score = NULL`
+(status "not started") — they were never refreshed before the API died.
+
+## Goal
+
+Restore live scoring for The Open Championship using the Data Golf API, as a
+**minimally invasive, single-season stopgap**. The wiring must be trivial to
+remove next season, when a permanent (cheaper) data source will be chosen.
+
+## Constraints & Key Facts
+
+- **Picks are matched to golfers by exact name string** (`compute_leaderboard`
+  does `golfers.get(pick)`). Both `entries.golfer_1..5` and `golfers.name` are
+  stored as `"First Last"` (e.g. `Scottie Scheffler`).
+- **Data Golf returns `"Last, First"`** (e.g. `Scheffler, Scottie`). Names must be
+  flipped and normalized before matching.
+- The refresh must **UPDATE existing golfer rows in place**, never INSERT — an
+  INSERT with a differently-formatted name would create duplicate rows and make
+  every pick score 999 ("not found").
+- Verified against live data (2026-07-16): **152 of 156 names auto-match**, and
+  **all 29 distinct picked golfers match**. The 4 unmatched are non-picked
+  nickname/spelling variants, handled by a small alias map.
+- Data Golf has **no numeric cut-line field** in any endpoint (verified against
+  docs + full field enumeration of `/preds/in-play` and
+  `/preds/live-tournament-stats`). Only `make_cut` (a probability) exists.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Automation | Auto via existing 5-min cron (route The Open through Data Golf) |
+| Gating | Hardcode The Open only (`external_id == '100'`); all other paths untouched |
+| Cut line | Derive from field: `max(current_score)` among players who made the cut |
+
+## Design
+
+### Data source
+
+`GET https://feeds.datagolf.com/preds/in-play?tour=pga&file_format=json&key=<DG_API_KEY>`
+
+Returns `{info: {...}, data: [ ...156 players... ]}`. Relevant per-player fields:
+`player_name` (`"Last, First"`), `current_pos` (`"T13"`, `"1"`, `"CUT"`),
+`current_score` (int total), `today` (int, current round), `thru`, `round`.
+`info.event_name` = `"The Open Championship"`, `info.current_round`.
+
+### New function: `refresh_golfers_from_datagolf(tournament_id, external_id, year)`
+
+Sits beside `refresh_golfers_from_api()`, writes to the same `golfers` table and
+`tournament_metadata`. Steps:
+
+1. Fetch the in-play feed. On network/HTTP/parse error → log, return `False`.
+2. **Wrong-event guard:** if `"open championship"` not in `info.event_name`
+   (lowercased) → log a warning and return `False`. Prevents clobbering The Open's
+   board if the PGA feed has rolled to a different event.
+3. Build `{normalized_name → actual_db_name}` from the tournament's existing rows.
+   Overlay `DG_NAME_ALIASES` (4 hardcoded variants) onto the lookup.
+4. For each Data Golf player:
+   - Flip `"Last, First"` → `"First Last"` (`_datagolf_flip_name`).
+   - Normalize via existing `_normalize_golfer_name`.
+   - Resolve to an existing DB row name. If unmatched → skip + log (never INSERT).
+   - **UPDATE** the row: `position`, `total_score`, `score_display`,
+     `current_round_score`, `round_number`, `thru`, `status`, `last_updated`.
+5. **Cut line:** if any player has `current_pos == "CUT"`, set
+   `cut_line = max(current_score)` over players whose `current_pos != "CUT"` and
+   `current_score is not None`. Otherwise `cut_line = None`.
+6. Upsert `tournament_metadata` with the cut line, `last_api_update = now`,
+   `api_status = 'success'`. Commit. Return `True`.
+
+### Field mapping
+
+| Data Golf | golfers column | Transform |
+|---|---|---|
+| `current_score` | `total_score` | int; `None` → `None` (not started) |
+| `current_score` | `score_display` | `E` (0) / `-2` / `+3` / `--` (None) |
+| `today` | `current_round_score` | same display format |
+| `current_pos` | `position` | as-is string |
+| `round` | `round_number` | int |
+| `thru` | `thru` | str(value) |
+| `current_pos == "CUT"` | `status` | `'cut'`, else `'active'`, else `'not started'` |
+
+`tee_time` is not provided by this endpoint and is left unchanged.
+
+### Status inference
+
+- `current_pos == "CUT"` → `status = 'cut'`
+- else if `current_score is None` and not yet started → `status = 'not started'`
+- else → `status = 'active'`
+
+Only `'cut'` is load-bearing (drives `apply_cut_modifier`); the rest is display.
+
+### The gate
+
+Single branch at the top of `refresh_golfers_from_api()`, covering all three
+callers (cron endpoint, admin manual refresh, tournament activation):
+
+```python
+# The Open Championship 2026: Slash Golf API disabled by provider mid-tournament.
+# Temporary Data Golf source — remove this whole branch next season.
+if tournament_external_id == '100':
+    return refresh_golfers_from_datagolf(tournament_id, tournament_external_id, year)
+```
+
+### Config
+
+- `DATAGOLF_BASE_URL = "https://feeds.datagolf.com"` constant.
+- Read `DG_API_KEY` from env (already in local `.env`).
+
+### Helpers added
+
+- `_datagolf_flip_name(name)` — `"Last, First"` → `"First Last"`.
+- `DG_NAME_ALIASES` — dict mapping the 4 known Data-Golf-normalized names to the
+  existing DB golfer names.
+- Small inline score-display formatter (`E`/`+N`/`-N`/`--`).
+
+## Error Handling
+
+- Any failure (network, HTTP, parse, wrong event) → log + return `False` →
+  endpoint returns 502, board holds last-good data. `last_api_update` only
+  advances on success, so a Data Golf outage looks like the current frozen state
+  rather than wiping scores.
+- Unmatched players are skipped, never inserted.
+
+## Testing
+
+- **Unit test** (no network): `_datagolf_flip_name` and name-resolution + alias
+  logic against a fixture of Data Golf names → expected DB names.
+- **Dry-run script** against live Data Golf: reads the feed, prints the mapped
+  scores per golfer and any unmatched names, writes nothing. Eyeball before the
+  first real refresh.
+- **One real refresh** via the admin refresh path, then spot-check the leaderboard
+  and `/players` page against Data Golf's live board.
+
+## Deployment
+
+- **Set `DG_API_KEY` in DigitalOcean App Platform env vars** — the production cron
+  calls the deployed app, which needs the key to authenticate to Data Golf.
+  Without it the refresh returns `False` and the board stays frozen.
+
+## Removal (next season)
+
+Delete `refresh_golfers_from_datagolf`, the gate branch, `_datagolf_flip_name`,
+`DG_NAME_ALIASES`, `DATAGOLF_BASE_URL`, and the `DG_API_KEY` env var. The original
+`refresh_golfers_from_api` Slash Golf path is untouched underneath.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,3 +103,46 @@ class TestValidateUserEmail:
 
     def test_empty_string(self):
         assert app_module.validate_user_email('') is None
+
+
+# ── _datagolf_flip_name (Data Golf hot-fix) ─────────────────────────────────
+
+class TestDatagolfFlipName:
+    def test_last_first(self):
+        assert app_module._datagolf_flip_name('Scheffler, Scottie') == 'Scottie Scheffler'
+
+    def test_strips_whitespace(self):
+        assert app_module._datagolf_flip_name('  Morikawa ,  Collin ') == 'Collin Morikawa'
+
+    def test_no_comma_passthrough(self):
+        assert app_module._datagolf_flip_name('Rory McIlroy') == 'Rory McIlroy'
+
+    def test_flipped_name_matches_db_via_normalize(self):
+        # The load-bearing property: a Data Golf name, flipped + normalized,
+        # matches the same normalized form as the "First Last" name in the DB.
+        dg = app_module._normalize_golfer_name(
+            app_module._datagolf_flip_name('Schauffele, Xander'))
+        db = app_module._normalize_golfer_name('Xander Schauffele')
+        assert dg == db
+
+    def test_alias_targets_are_first_last(self):
+        # Every alias must map a raw Data Golf name to a plausible "First Last" DB name.
+        for dg_name, db_name in app_module.DG_NAME_ALIASES.items():
+            assert ',' not in db_name
+            assert db_name.strip() == db_name
+
+
+# ── _format_golf_score (Data Golf hot-fix) ──────────────────────────────────
+
+class TestFormatGolfScore:
+    def test_even(self):
+        assert app_module._format_golf_score(0) == 'E'
+
+    def test_negative(self):
+        assert app_module._format_golf_score(-5) == '-5'
+
+    def test_positive_gets_plus(self):
+        assert app_module._format_golf_score(3) == '+3'
+
+    def test_none_is_dashes(self):
+        assert app_module._format_golf_score(None) == '--'


### PR DESCRIPTION
## Why

The Slash Golf API (`live-golf-data.p.rapidapi.com`) was **disabled by its provider mid-tournament** — every endpoint returns `405 "The API provider has disabled request access to the API."` This froze The Open Championship leaderboard (last successful update was the day before, and the 156 golfer rows had no scores at all).

## What

A minimally-invasive, **single-season stopgap** that pulls live scores from the **Data Golf** API for The Open only.

- **New `refresh_golfers_from_datagolf()`** — sources `/preds/in-play` (PGA feed) and **UPDATEs the existing 156 golfer rows in place** (matched by normalized name, never inserted), so pick-to-golfer matching and row identity are preserved.
- **Name handling** — Data Golf returns `"Last, First"`; `_datagolf_flip_name()` flips it and reuses the existing `_normalize_golfer_name()`. A 4-entry `DG_NAME_ALIASES` map covers non-picked nickname variants. **Verified 156/156 names match** live, including all 29 distinct picked golfers.
- **Cut line** — Data Golf exposes no cut-line score, so it's derived as the worst total among players who made the cut, matching `apply_cut_modifier` semantics. Stays `None` until Friday's cut.
- **Gate** — a single branch at the top of `refresh_golfers_from_api` (`external_id == '100'`) routes cron, admin refresh, and activation through Data Golf for The Open only. Everything else is untouched.
- **Fails safe** — any error (network, wrong event, parse) logs and returns `False`, holding last-good data. `last_api_update` only advances on success.
- Unit tests for the pure name-flip/format helpers; full suite (138) passes.

## Deploy requirement

⚠️ **`DG_API_KEY` must be set in DigitalOcean App Platform env vars** — the deployed cron needs it to authenticate to Data Golf. Without it the board stays frozen after deploy.

## Removal next season

Delete `refresh_golfers_from_datagolf`, the gate branch, `_datagolf_flip_name`, `_format_golf_score`, `DG_NAME_ALIASES`, `DATAGOLF_BASE_URL`, and the `DG_API_KEY` env var. The original Slash Golf path is untouched underneath.

Design doc: `docs/superpowers/specs/2026-07-16-datagolf-open-hotfix-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5AcH8d8i95hw7UPcXFN3V